### PR TITLE
Return start/goal indices and planning stats in PlanResult

### DIFF
--- a/src/pycbirrt/planner.py
+++ b/src/pycbirrt/planner.py
@@ -4,6 +4,7 @@ import time
 
 import numpy as np
 from tsr import TSR
+from tsr import choose_tsr_index
 from tsr.sampling import sample_from_tsrs
 
 from pycbirrt.config import CBiRRTConfig
@@ -21,12 +22,26 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class PlanResult:
-    """Result of a planning query."""
+    """Result of a planning query.
+
+    Attributes:
+        path: Joint configurations from start to goal, or None if failed.
+        start_index: Index into the start input (config list or TSR list)
+            that the path begins from. Always 0 for single start.
+        goal_index: Index into the goal input (config list or TSR list)
+            that the path ends at. Always 0 for single goal.
+        iterations: Number of RRT iterations used.
+        planning_time: Wall-clock time in seconds.
+        tree_sizes: Tuple of (start_tree_size, goal_tree_size).
+        success: Whether a path was found.
+    """
 
     path: list[np.ndarray] | None
-    tree_start: RRTree
-    tree_goal: RRTree
+    start_index: int
+    goal_index: int
     iterations: int
+    planning_time: float
+    tree_sizes: tuple[int, int]
     success: bool
 
 
@@ -143,28 +158,48 @@ class CBiRRT:
         # Initialize start configurations
         # Validation errors (invalid configs) should propagate up
         # Only sampling failures return None
-        start_roots = self._initialize_tree_configs(
+        start_roots, start_source_indices = self._initialize_tree_configs(
             start_configs, start_tsrs, "Start"
         )
 
         # Initialize goal configurations
-        goal_roots = self._initialize_tree_configs(
+        goal_roots, goal_source_indices = self._initialize_tree_configs(
             goal_configs, goal_tsrs, "Goal"
         )
 
-        # Initialize trees with multiple roots
-        tree_start = RRTree(start_roots if len(start_roots) > 1 else start_roots[0])
-        tree_goal = RRTree(goal_roots if len(goal_roots) > 1 else goal_roots[0])
+        # Initialize trees with multiple roots and source indices
+        tree_start = RRTree(
+            start_roots if len(start_roots) > 1 else start_roots[0],
+            source_indices=start_source_indices,
+        )
+        tree_goal = RRTree(
+            goal_roots if len(goal_roots) > 1 else goal_roots[0],
+            source_indices=goal_source_indices,
+        )
 
         # Track start time for timeout
         start_time = time.monotonic()
+
+        def _make_result(path, iteration, success):
+            elapsed = time.monotonic() - start_time
+            si = tree_start.get_root_source_index(0) if success else 0
+            gi = tree_goal.get_root_source_index(0) if success else 0
+            return PlanResult(
+                path=path,
+                start_index=si,
+                goal_index=gi,
+                iterations=iteration,
+                planning_time=elapsed,
+                tree_sizes=(len(tree_start), len(tree_goal)),
+                success=success,
+            )
 
         # Main planning loop
         for iteration in range(self.config.max_iterations):
             # Check timeout
             if time.monotonic() - start_time > self.config.timeout:
                 if return_details:
-                    return PlanResult(None, tree_start, tree_goal, iteration, False)
+                    return _make_result(None, iteration, False)
                 return None
 
             # Alternate which tree we extend
@@ -197,12 +232,29 @@ class CBiRRT:
                 if self.config.smooth_path:
                     path = self._smooth_path(path)
 
+                # Determine which start/goal roots were used
+                if tree_a is tree_start:
+                    si = tree_start.get_root_source_index(grow_idx)
+                    gi = tree_goal.get_root_source_index(connect_idx)
+                else:
+                    si = tree_start.get_root_source_index(connect_idx)
+                    gi = tree_goal.get_root_source_index(grow_idx)
+
+                elapsed = time.monotonic() - start_time
                 if return_details:
-                    return PlanResult(path, tree_start, tree_goal, iteration + 1, True)
+                    return PlanResult(
+                        path=path,
+                        start_index=si if si is not None else 0,
+                        goal_index=gi if gi is not None else 0,
+                        iterations=iteration + 1,
+                        planning_time=elapsed,
+                        tree_sizes=(len(tree_start), len(tree_goal)),
+                        success=True,
+                    )
                 return path
 
         if return_details:
-            return PlanResult(None, tree_start, tree_goal, self.config.max_iterations, False)
+            return _make_result(None, self.config.max_iterations, False)
         return None
 
     def _sample_from_tsrs(
@@ -233,7 +285,7 @@ class CBiRRT:
 
     def _sample_configs_from_tsrs(
         self, tsrs: list[TSR], target_count: int, must_satisfy_constraints: bool = False
-    ) -> list[np.ndarray]:
+    ) -> tuple[list[np.ndarray], list[int]]:
         """Sample multiple valid configurations from TSRs for tree initialization.
 
         Samples poses and collects IK solutions from each (up to max_ik_per_pose)
@@ -246,16 +298,19 @@ class CBiRRT:
             must_satisfy_constraints: If True, also check path constraint TSRs
 
         Returns:
-            List of valid configurations (may be less than target_count)
+            Tuple of (configs, tsr_indices) where tsr_indices[i] is the index
+            into tsrs that produced configs[i].
         """
         configs = []
+        tsr_indices = []
         max_per_pose = self.config.max_ik_per_pose
 
         for _ in range(self.config.tsr_samples):
             if len(configs) >= target_count:
                 break
 
-            pose = sample_from_tsrs(tsrs, self._rng)
+            tsr_idx = choose_tsr_index(tsrs, self._rng)
+            pose = tsrs[tsr_idx].sample()
             solutions = self.ik.solve_valid(pose)
 
             # Cap solutions per pose for diversity
@@ -266,11 +321,12 @@ class CBiRRT:
                 if must_satisfy_constraints and not self._satisfies_constraints(q):
                     continue
                 configs.append(q)
+                tsr_indices.append(tsr_idx)
                 added_from_pose += 1
                 if len(configs) >= target_count:
                     break
 
-        return configs
+        return configs, tsr_indices
 
     def _satisfies_constraints(self, q: np.ndarray) -> bool:
         """Check if configuration satisfies all path constraint TSRs.
@@ -315,7 +371,7 @@ class CBiRRT:
         fixed_configs: list[np.ndarray] | None,
         tsrs: list[TSR] | None,
         config_type: str,  # "Start" or "Goal"
-    ) -> list[np.ndarray]:
+    ) -> tuple[list[np.ndarray], list[int]]:
         """Initialize tree with fixed configs and TSR samples.
 
         Validates all fixed configurations before proceeding. If some configs
@@ -329,7 +385,11 @@ class CBiRRT:
             config_type: "Start" or "Goal" for error messages
 
         Returns:
-            List of valid root configurations
+            Tuple of (valid_configs, source_indices) where source_indices[i]
+            is the index into fixed_configs or tsrs that produced config i.
+            For fixed configs, the index is the position in the input list.
+            For TSR-sampled configs, the index is currently 0 (TSR index
+            tracking requires changes to sample_from_tsrs).
 
         Raises:
             AllStartConfigurationsInCollision: If all start configs are in collision
@@ -339,6 +399,7 @@ class CBiRRT:
             ValueError: If no configs available at all
         """
         valid_configs = []
+        source_indices = []
         invalid_details = []
         all_in_collision = True
 
@@ -348,6 +409,7 @@ class CBiRRT:
                 is_valid, reason = self._check_config(q)
                 if is_valid:
                     valid_configs.append(q)
+                    source_indices.append(i)
                 else:
                     invalid_details.append(f"{config_type}[{i}]: {reason}")
                     if reason != "in collision":
@@ -365,12 +427,14 @@ class CBiRRT:
             must_satisfy = self._constraint_tsrs is not None
             needed = max(0, self.config.num_tree_roots - len(valid_configs))
             if needed > 0:
-                sampled = self._sample_configs_from_tsrs(tsrs, needed, must_satisfy)
-                valid_configs.extend(sampled)
+                sampled, tsr_indices = self._sample_configs_from_tsrs(tsrs, needed, must_satisfy)
+                for q, tsr_idx in zip(sampled, tsr_indices):
+                    valid_configs.append(q)
+                    source_indices.append(tsr_idx)
 
         # If we have valid configs, return them
         if valid_configs:
-            return valid_configs
+            return valid_configs, source_indices
 
         # No valid configs - raise appropriate exception
         if fixed_configs is not None and len(fixed_configs) > 0:

--- a/src/pycbirrt/tree.py
+++ b/src/pycbirrt/tree.py
@@ -8,17 +8,24 @@ class Node:
 
     config: np.ndarray
     parent: int | None = None  # Index of parent node, None for root
+    source_index: int | None = None  # Index into the input list that produced this root
 
 
 class RRTree:
     """Rapidly-exploring Random Tree data structure."""
 
-    def __init__(self, root_config: np.ndarray | list[np.ndarray]):
+    def __init__(
+        self,
+        root_config: np.ndarray | list[np.ndarray],
+        source_indices: list[int] | None = None,
+    ):
         """Initialize tree with one or more root nodes.
 
         Args:
             root_config: Single configuration or list of configurations.
                         All provided configs become roots (parent=None).
+            source_indices: Optional index per root, tracking which input
+                           (config or TSR) produced it. Same length as configs.
         """
         # Normalize to list
         if isinstance(root_config, np.ndarray):
@@ -31,8 +38,9 @@ class RRTree:
         self._configs_array: np.ndarray | None = None  # Cached for nearest()
 
         # Add all configs as roots
-        for config in configs:
-            self.nodes.append(Node(config=config.copy(), parent=None))
+        for i, config in enumerate(configs):
+            src_idx = source_indices[i] if source_indices is not None else i
+            self.nodes.append(Node(config=config.copy(), parent=None, source_index=src_idx))
             self._configs.append(config.copy())
 
     def add_node(self, config: np.ndarray, parent_idx: int) -> int:
@@ -83,6 +91,13 @@ class RRTree:
 
     def __len__(self) -> int:
         return len(self.nodes)
+
+    def get_root_source_index(self, node_idx: int) -> int | None:
+        """Trace a node back to its root and return the source_index."""
+        idx = node_idx
+        while self.nodes[idx].parent is not None:
+            idx = self.nodes[idx].parent
+        return self.nodes[idx].source_index
 
     @property
     def num_roots(self) -> int:

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -889,3 +889,138 @@ class TestTreeCaching:
         # Add a third node closer to query
         tree.add_node(np.array([9.5, 9.5]), 1)
         assert tree.nearest(np.array([9.0, 9.0])) == 2
+
+
+class TestPlanResultIndices:
+    """Verify start_index and goal_index point to the correct TSR/config."""
+
+    @pytest.fixture
+    def planner(self):
+        robot = MockRobotModel()
+        collision = MockCollisionChecker()
+        ik = MockIKSolver(robot, collision)
+        return CBiRRT(robot=robot, ik_solver=ik, collision_checker=collision), robot
+
+    def _make_point_tsr(self, x, y, tol=0.1):
+        """Create a small TSR at (x, y)."""
+        T0_w = np.eye(4)
+        T0_w[0, 3] = x
+        T0_w[1, 3] = y
+        Bw = np.array([
+            [-tol, tol], [-tol, tol], [0, 0],
+            [0, 0], [0, 0], [0, 0],
+        ])
+        return TSR(T0_w=T0_w, Tw_e=np.eye(4), Bw=Bw)
+
+    def test_goal_index_matches_reached_tsr(self, planner):
+        """goal_index should point to the TSR closest to path[-1]."""
+        cbrt, robot = planner
+
+        start = np.array([0.0, 0.5])
+
+        # Two well-separated goal TSRs
+        tsr_a = self._make_point_tsr(1.5, 0.5)  # index 0
+        tsr_b = self._make_point_tsr(-1.5, 0.5)  # index 1
+
+        result = cbrt.plan(
+            start=start,
+            goal_tsrs=[tsr_a, tsr_b],
+            return_details=True,
+        )
+        assert result.success
+
+        # Compute EE pose at path end
+        ee_pose = robot.forward_kinematics(result.path[-1])
+
+        # The reached TSR should have ~zero distance
+        dist_a, _ = tsr_a.distance(ee_pose)
+        dist_b, _ = tsr_b.distance(ee_pose)
+
+        if result.goal_index == 0:
+            assert dist_a < 0.15, f"goal_index=0 but dist to TSR[0]={dist_a:.3f}"
+            assert dist_b > dist_a, "goal_index=0 but TSR[1] is closer"
+        else:
+            assert dist_b < 0.15, f"goal_index=1 but dist to TSR[1]={dist_b:.3f}"
+            assert dist_a > dist_b, "goal_index=1 but TSR[0] is closer"
+
+    def test_start_index_matches_reached_tsr(self, planner):
+        """start_index should point to the TSR closest to path[0]."""
+        cbrt, robot = planner
+
+        goal = np.array([0.0, 0.5])
+
+        # Two well-separated start TSRs
+        tsr_a = self._make_point_tsr(1.5, 0.5)  # index 0
+        tsr_b = self._make_point_tsr(-1.5, 0.5)  # index 1
+
+        result = cbrt.plan(
+            start_tsrs=[tsr_a, tsr_b],
+            goal=goal,
+            return_details=True,
+        )
+        assert result.success
+
+        # Compute EE pose at path start
+        ee_pose = robot.forward_kinematics(result.path[0])
+
+        dist_a, _ = tsr_a.distance(ee_pose)
+        dist_b, _ = tsr_b.distance(ee_pose)
+
+        if result.start_index == 0:
+            assert dist_a < 0.15, f"start_index=0 but dist to TSR[0]={dist_a:.3f}"
+            assert dist_b > dist_a, "start_index=0 but TSR[1] is closer"
+        else:
+            assert dist_b < 0.15, f"start_index=1 but dist to TSR[1]={dist_b:.3f}"
+            assert dist_a > dist_b, "start_index=1 but TSR[0] is closer"
+
+    def test_goal_index_with_multiple_configs(self, planner):
+        """goal_index with config list should match path[-1]."""
+        cbrt, robot = planner
+
+        start = np.array([0.0, 0.5])
+        goal_a = np.array([1.0, 0.5])  # index 0
+        goal_b = np.array([-1.0, 0.5])  # index 1
+
+        result = cbrt.plan(
+            start=start,
+            goal=[goal_a, goal_b],
+            return_details=True,
+        )
+        assert result.success
+
+        end = result.path[-1]
+        dist_a = np.linalg.norm(end - goal_a)
+        dist_b = np.linalg.norm(end - goal_b)
+
+        if result.goal_index == 0:
+            assert dist_a < dist_b
+        else:
+            assert dist_b < dist_a
+
+    def test_single_start_goal_returns_zero(self, planner):
+        """Single start and goal should return index 0."""
+        cbrt, robot = planner
+
+        result = cbrt.plan(
+            start=np.array([0.0, 0.5]),
+            goal=np.array([0.5, 0.5]),
+            return_details=True,
+        )
+        assert result.success
+        assert result.start_index == 0
+        assert result.goal_index == 0
+
+    def test_planning_stats_populated(self, planner):
+        """Planning stats should be populated on success and failure."""
+        cbrt, robot = planner
+
+        result = cbrt.plan(
+            start=np.array([0.0, 0.5]),
+            goal=np.array([0.5, 0.5]),
+            return_details=True,
+        )
+        assert result.success
+        assert result.planning_time > 0
+        assert result.iterations > 0
+        assert result.tree_sizes[0] > 0
+        assert result.tree_sizes[1] > 0


### PR DESCRIPTION
## Summary

- `PlanResult` now includes `start_index`, `goal_index`, `planning_time`, `tree_sizes`
- Each tree root tracks which input (config or TSR) produced it via `source_index`
- When path is found, traces back to roots to determine which start/goal was used
- Always returns an index (0 for single start/goal)

## Use case

Send grasp TSRs from multiple objects → planner picks easiest → caller knows which object via `goal_index`.

## Test plan

- [x] 37 pycbirrt tests passing
- [x] 239 mj_manipulator tests passing (backward compatible)
- [x] 47 geodude tests passing

Closes #8