### PR TITLE
Collision-check TSR-sampled goal configs

### DIFF
--- a/src/pycbirrt/planner.py
+++ b/src/pycbirrt/planner.py
@@ -34,6 +34,7 @@ class PlanResult:
         planning_time: Wall-clock time in seconds.
         tree_sizes: Tuple of (start_tree_size, goal_tree_size).
         success: Whether a path was found.
+        failure_reason: Human-readable reason for failure, or None if success.
     """
 
     path: list[np.ndarray] | None
@@ -43,6 +44,7 @@ class PlanResult:
     planning_time: float
     tree_sizes: tuple[int, int]
     success: bool
+    failure_reason: str | None = None
 
 
 class CBiRRT:
@@ -180,7 +182,7 @@ class CBiRRT:
         # Track start time for timeout
         start_time = time.monotonic()
 
-        def _make_result(path, iteration, success):
+        def _make_result(path, iteration, success, failure_reason=None):
             elapsed = time.monotonic() - start_time
             si = tree_start.get_root_source_index(0) if success else 0
             gi = tree_goal.get_root_source_index(0) if success else 0
@@ -192,14 +194,20 @@ class CBiRRT:
                 planning_time=elapsed,
                 tree_sizes=(len(tree_start), len(tree_goal)),
                 success=success,
+                failure_reason=failure_reason,
             )
 
         # Main planning loop
         for iteration in range(self.config.max_iterations):
             # Check timeout
             if time.monotonic() - start_time > self.config.timeout:
+                reason = (
+                    f"Timeout after {self.config.timeout:.1f}s, {iteration} iterations. "
+                    f"Trees: start={len(tree_start)} nodes, goal={len(tree_goal)} nodes. "
+                    f"Trees could not connect."
+                )
                 if return_details:
-                    return _make_result(None, iteration, False)
+                    return _make_result(None, iteration, False, failure_reason=reason)
                 return None
 
             # Alternate which tree we extend
@@ -253,8 +261,13 @@ class CBiRRT:
                     )
                 return path
 
+        reason = (
+            f"Max iterations ({self.config.max_iterations}) reached. "
+            f"Trees: start={len(tree_start)} nodes, goal={len(tree_goal)} nodes. "
+            f"Trees could not connect."
+        )
         if return_details:
-            return _make_result(None, self.config.max_iterations, False)
+            return _make_result(None, self.config.max_iterations, False, failure_reason=reason)
         return None
 
     def _sample_from_tsrs(

--- a/src/pycbirrt/planner.py
+++ b/src/pycbirrt/planner.py
@@ -232,7 +232,7 @@ class CBiRRT:
                 if self.config.smooth_path:
                     path = self._smooth_path(path)
 
-                # Determine which start/goal roots were used
+                # Determine which start/goal was used by tracing to root
                 if tree_a is tree_start:
                     si = tree_start.get_root_source_index(grow_idx)
                     gi = tree_goal.get_root_source_index(connect_idx)
@@ -318,6 +318,8 @@ class CBiRRT:
             for q in solutions:
                 if added_from_pose >= max_per_pose:
                     break
+                if not self.collision.is_valid(q):
+                    continue
                 if must_satisfy_constraints and not self._satisfies_constraints(q):
                     continue
                 configs.append(q)

--- a/src/pycbirrt/planner.py
+++ b/src/pycbirrt/planner.py
@@ -285,7 +285,7 @@ class CBiRRT:
 
     def _sample_configs_from_tsrs(
         self, tsrs: list[TSR], target_count: int, must_satisfy_constraints: bool = False
-    ) -> tuple[list[np.ndarray], list[int]]:
+    ) -> tuple[list[np.ndarray], list[int], dict[str, int]]:
         """Sample multiple valid configurations from TSRs for tree initialization.
 
         Samples poses and collects IK solutions from each (up to max_ik_per_pose)
@@ -298,11 +298,14 @@ class CBiRRT:
             must_satisfy_constraints: If True, also check path constraint TSRs
 
         Returns:
-            Tuple of (configs, tsr_indices) where tsr_indices[i] is the index
-            into tsrs that produced configs[i].
+            Tuple of (configs, tsr_indices, stats) where:
+            - configs: valid configurations
+            - tsr_indices[i]: index into tsrs that produced configs[i]
+            - stats: rejection counts {"ik_failed", "in_collision", "constraint_violated"}
         """
         configs = []
         tsr_indices = []
+        stats = {"ik_failed": 0, "in_collision": 0, "constraint_violated": 0}
         max_per_pose = self.config.max_ik_per_pose
 
         for _ in range(self.config.tsr_samples):
@@ -313,14 +316,20 @@ class CBiRRT:
             pose = tsrs[tsr_idx].sample()
             solutions = self.ik.solve_valid(pose)
 
+            if not solutions:
+                stats["ik_failed"] += 1
+                continue
+
             # Cap solutions per pose for diversity
             added_from_pose = 0
             for q in solutions:
                 if added_from_pose >= max_per_pose:
                     break
                 if not self.collision.is_valid(q):
+                    stats["in_collision"] += 1
                     continue
                 if must_satisfy_constraints and not self._satisfies_constraints(q):
+                    stats["constraint_violated"] += 1
                     continue
                 configs.append(q)
                 tsr_indices.append(tsr_idx)
@@ -328,7 +337,7 @@ class CBiRRT:
                 if len(configs) >= target_count:
                     break
 
-        return configs, tsr_indices
+        return configs, tsr_indices, stats
 
     def _satisfies_constraints(self, q: np.ndarray) -> bool:
         """Check if configuration satisfies all path constraint TSRs.
@@ -425,11 +434,14 @@ class CBiRRT:
             )
 
         # Sample from TSRs to fill up to num_tree_roots configs
+        tsr_stats = None
         if tsrs is not None:
             must_satisfy = self._constraint_tsrs is not None
             needed = max(0, self.config.num_tree_roots - len(valid_configs))
             if needed > 0:
-                sampled, tsr_indices = self._sample_configs_from_tsrs(tsrs, needed, must_satisfy)
+                sampled, tsr_indices, tsr_stats = self._sample_configs_from_tsrs(
+                    tsrs, needed, must_satisfy,
+                )
                 for q, tsr_idx in zip(sampled, tsr_indices):
                     valid_configs.append(q)
                     source_indices.append(tsr_idx)
@@ -452,6 +464,26 @@ class CBiRRT:
                     raise AllGoalConfigurationsInCollision(n_configs, invalid_details)
                 else:
                     raise AllGoalConfigurationsInvalid(n_configs, invalid_details)
+
+        # TSR sampling failed — report why
+        if tsr_stats is not None:
+            total_attempts = sum(tsr_stats.values())
+            if total_attempts > 0:
+                details = []
+                if tsr_stats["ik_failed"]:
+                    details.append(f"{tsr_stats['ik_failed']} IK unreachable")
+                if tsr_stats["in_collision"]:
+                    details.append(f"{tsr_stats['in_collision']} in collision")
+                if tsr_stats["constraint_violated"]:
+                    details.append(f"{tsr_stats['constraint_violated']} constraint violated")
+                summary = ", ".join(details)
+
+                if tsr_stats["in_collision"] and not tsr_stats["ik_failed"]:
+                    Ex = AllGoalConfigurationsInCollision if config_type == "Goal" else AllStartConfigurationsInCollision
+                    raise Ex(tsr_stats["in_collision"], [summary])
+                else:
+                    Ex = AllGoalConfigurationsInvalid if config_type == "Goal" else AllStartConfigurationsInvalid
+                    raise Ex(total_attempts, [summary])
 
         # No configs provided at all
         raise ValueError(


### PR DESCRIPTION
## Summary

Three improvements to planning failure reporting:

### 1. Collision-check TSR-sampled goal configs
`_sample_configs_from_tsrs` accepted IK solutions without collision checking. This seeded goal trees with deeply colliding configs (37-76mm table penetration), producing plans that were invalid from the start.

### 2. Report why TSR sampling failed
When all goal configs are rejected, the error now distinguishes:
- `"100 IK unreachable"` — poses are kinematically out of reach
- `"15 in collision"` — IK solutions collide with environment
- `"80 IK unreachable, 15 in collision"` — mixed

### 3. Add `failure_reason` to `PlanResult`
Timeout and max-iterations failures now include a reason:
- `"Timeout after 10.0s, 5000 iterations. Trees: start=2400, goal=1800. Trees could not connect."`
- `"Max iterations (5000) reached. Trees: start=2400, goal=1800. Trees could not connect."`

Fixes #10

## Test plan

- [x] `uv run pytest tests/ -v` — 42 passed
- [x] Verified: 0 colliding paths (was ~100% before)
- [x] Error messages confirmed for IK-unreachable and collision cases
- [ ] Downstream: personalrobotics/mj_manipulator#33 surfaces these in BT nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)