### PR TITLE
Add abort_fn callback to stop planning early

### DIFF
--- a/src/pycbirrt/config.py
+++ b/src/pycbirrt/config.py
@@ -1,4 +1,5 @@
-from dataclasses import dataclass
+from collections.abc import Callable
+from dataclasses import dataclass, field
 
 
 @dataclass
@@ -48,3 +49,6 @@ class CBiRRTConfig:
     # If None, all joints are treated as linear
     # If provided, boolean array where True = angular joint (handles 2*pi wraparound)
     angular_joints: tuple[bool, ...] | None = None
+
+    # Abort callback — return True to stop planning early
+    abort_fn: Callable[[], bool] | None = field(default=None, repr=False)

--- a/src/pycbirrt/planner.py
+++ b/src/pycbirrt/planner.py
@@ -199,6 +199,13 @@ class CBiRRT:
 
         # Main planning loop
         for iteration in range(self.config.max_iterations):
+            # Check abort
+            if self.config.abort_fn is not None and self.config.abort_fn():
+                reason = "Aborted by user"
+                if return_details:
+                    return _make_result(None, iteration, False, failure_reason=reason)
+                return None
+
             # Check timeout
             if time.monotonic() - start_time > self.config.timeout:
                 reason = (


### PR DESCRIPTION
## Summary
- Adds optional `abort_fn: Callable[[], bool]` field to `CBiRRTConfig`
- Planner checks it once per iteration in the main loop; returns early with `failure_reason="Aborted by user"` if True
- Zero overhead when not set (one `is not None` check per iteration)

Part of the abort mechanism for geodude#123.

## Test plan
- [x] `uv run pytest tests/ -v` — 42 tests pass
- [ ] Manual: set abort_fn to lambda that returns True after 0.1s, verify planner returns quickly with correct failure_reason