### PR TITLE
CI: use --no-sources for standalone uv sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --all-extras --dev
+        run: uv sync --all-extras --dev --no-sources
 
       - name: Ruff lint
         run: uv run ruff check .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,11 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # Standalone CI has no workspace context. Skip [tool.uv.sources]
+  # workspace overrides and use the git URLs in dependencies instead.
+  UV_NO_SOURCES: "true"
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -27,8 +32,11 @@ jobs:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
 
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libeigen3-dev
+
       - name: Install dependencies
-        run: uv sync --all-extras --dev --no-sources
+        run: uv sync --all-extras --dev
 
       - name: Ruff lint
         run: uv run ruff check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ maintainers = [
 ]
 dependencies = [
     "numpy>=1.24",
-    "tsr",
+    "tsr @ git+https://github.com/personalrobotics/tsr.git",
 ]
 
 [tool.uv.sources]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ examples = [
 dev = [
     "pytest>=7.0",
     "pytest-cov",
+    "ruff",
 ]
 all = ["pycbirrt[mujoco,eaik,examples,dev]"]
 


### PR DESCRIPTION
## Summary
Fix standalone CI: `uv sync` fails because `workspace = true` overrides in `[tool.uv.sources]` don't resolve outside the robot-code workspace. `--no-sources` skips these overrides and falls back to the git URLs in `dependencies`.

## Test plan
- [ ] CI passes on this PR (the fix is self-verifying)

🤖 Generated with [Claude Code](https://claude.com/claude-code)